### PR TITLE
Allow cancellation of ongoing auth flows

### DIFF
--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -37,10 +37,11 @@ class Authenticator {
   }
 
   /// cancel the ongoing auth flow, i.e. when the user closed the webview/browser without a successful login
-  void cancel() {
-    var state = flow.authenticationUri.queryParameters["state"];
+  Future<void> cancel() async {
+    final state = flow.authenticationUri.queryParameters["state"];
     _requestsByState[state]?.completeError("cancelled");
-    _requestServers.remove(port)?.then((s) => s.close());
+    final server = await _requestServers.remove(port);
+    await server.close();
   }
 
   static Map<int, Future<HttpServer>> _requestServers = {};

--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -36,6 +36,13 @@ class Authenticator {
     return flow.callback(response);
   }
 
+  /// cancel the ongoing auth flow, i.e. when the user closed the webview/browser without a successful login
+  void cancel() {
+    var state = flow.authenticationUri.queryParameters["state"];
+    _requestsByState[state]?.completeError("cancelled");
+    _requestServers.remove(port)?.then((s) => s.close());
+  }
+
   static Map<int, Future<HttpServer>> _requestServers = {};
   static Map<String, Completer<Map<String, String>>> _requestsByState = {};
 

--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -39,7 +39,7 @@ class Authenticator {
   /// cancel the ongoing auth flow, i.e. when the user closed the webview/browser without a successful login
   Future<void> cancel() async {
     final state = flow.authenticationUri.queryParameters["state"];
-    _requestsByState[state]?.completeError("cancelled");
+    _requestsByState[state]?.completeError(new Exception("Flow was cancelled"));
     final server = await _requestServers.remove(port);
     await server.close();
   }

--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -41,7 +41,9 @@ class Authenticator {
     final state = flow.authenticationUri.queryParameters["state"];
     _requestsByState[state]?.completeError(new Exception("Flow was cancelled"));
     final server = await _requestServers.remove(port);
-    await server.close();
+    if (server != null) {
+      await server.close();
+    }
   }
 
   static Map<int, Future<HttpServer>> _requestServers = {};


### PR DESCRIPTION
Users may leave the login page without logging in. In such cases `Authenticator.authorize()` never completes and the server runs forever. The new method `Authenticator.cancel()` allows to cancel a flow and frees resources.