### PR TITLE
Fix missing token field in client.createCredential

### DIFF
--- a/lib/src/openid.dart
+++ b/lib/src/openid.dart
@@ -153,14 +153,16 @@ class Client {
           {String accessToken,
           String tokenType,
           String refreshToken,
-          String idToken}) =>
+          String idToken,
+          int expiresIn}) =>
       Credential._(
           this,
           TokenResponse.fromJson({
             'access_token': accessToken,
             'token_type': tokenType,
             'refresh_token': refreshToken,
-            'id_token': idToken
+            'id_token': idToken,
+            'expires_in': expiresIn
           }),
           null);
 }


### PR DESCRIPTION
Before, `getTokenResponse()` would throw a NPE, given that `expires_in` and therefore `expires_at` were not set. 

Compare also 
https://github.com/appsup-dart/openid_client/blob/master/lib/src/model/token_response.dart#L29