### PR TITLE
Handling the exception where a request is unsuccessful (not a 2xx status code) and the response's body it's not a JSON.

### DIFF
--- a/lib/src/http_util.dart
+++ b/lib/src/http_util.dart
@@ -75,4 +75,9 @@ class HttpRequestException implements Exception {
   final dynamic body;
 
   HttpRequestException({required this.statusCode, this.body});
+
+  @override
+  String toString() {
+    return 'HttpRequestException >>> statusCode: $statusCode, body: $body';
+  }
 }


### PR DESCRIPTION
The `openid_client` now expects unsuccessful responses to contain JSON in response's body. In the case that the body is not a JSON then a `FormatException` is thrown (by `json.decode()`).

But there exists cases where the body of an unsuccessful response it's not a JSON. Take for example a classic 502 error-response (this one is a Nginx's one):

```txt
HTTP/2 502 
server: nginx/1.18.0 (Ubuntu)
date: Tue, 16 Mar 2021 09:53:29 GMT
content-type: text/html
content-length: 166

<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```
The solution proposed in the _Pull Request_ tries to deserialize the response's body only if the `content-type` of the request is set to `application/json`. The solution also handles cases where the body should be a JSON, but it's for some reason not-parsable. If a deserialization is not possible then the body will be stored in the `HttpRequestException` as-is (in a `String`). 
