### PR TITLE
Expose flow constructors for customisation

### DIFF
--- a/lib/openid_client_browser.dart
+++ b/lib/openid_client_browser.dart
@@ -5,15 +5,16 @@ import 'dart:convert';
 export 'openid_client.dart';
 
 class Authenticator {
+  static String? storedState() => window.localStorage['openid_client:state'];
+
   final Flow flow;
 
   final Future<Credential?> credential;
 
-  Authenticator._(this.flow) : credential = _credentialFromUri(flow);
+  Authenticator.flow(this.flow) : credential = _credentialFromUri(flow);
 
   Authenticator(Client client, {Iterable<String> scopes = const []})
-      : this._(Flow.implicit(client,
-            state: window.localStorage['openid_client:state'])
+      : this.flow(Flow.implicit(client, state: storedState())
           ..scopes.addAll(scopes)
           ..redirectUri = Uri.parse(window.location.href).removeFragment());
 

--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -24,6 +24,12 @@ class Authenticator {
           ..scopes.addAll(scopes)
           ..redirectUri = redirectUri ?? Uri.parse('http://localhost:$port/');
 
+  Authenticator.flow(
+    this.flow, {
+    this.urlLancher = _runBrowser,
+    this.port = 3000,
+  });
+
   Future<Credential> authorize() async {
     var state = flow.authenticationUri.queryParameters['state']!;
 


### PR DESCRIPTION
As per [issue #36](https://github.com/appsup-dart/openid_client/issues/36) PKCE seems to grow quite popular, which makes sense to extend Authenticator to allow developers set their desired Flow.

I have also exposed the a read-only `storedState()` for web's version so it could be used to be injected into the desired custom flow.

Usage example:

```
final authenticator = Authenticator.flow(
      Flow.authorizationCodeWithPKCE(client, state: Authenticator.storedState())
        ..scopes.addAll(scopes)
        ..redirectUri = Uri.parse('http://localhost:3000/login'),
    );
```

Please let me know if this approach is acceptable or if some more work needs to be done. I'm happy to help.

Thank you