### PR TITLE
Allow to process result from the outside

### DIFF
--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -65,18 +65,25 @@ class Authenticator {
               var result = request.requestedUri.queryParameters;
 
               if (!result.containsKey('state')) continue;
-              var r = _requestsByState.remove(result['state'])!;
-              r.complete(result);
-              if (_requestsByState.isEmpty) {
-                for (var s in _requestServers.values) {
-                  await (await s).close();
-                }
-                _requestServers.clear();
-              }
+              await processResult(result);
             }
 
             await _requestServers.remove(port);
           }));
+  }
+
+
+  /// Process the Result from a auth Request
+  /// You can call this manually if you are redirected to the app by an external browser
+  static Future<void> processResult(Map<String, String> result) async {
+    var r = _requestsByState.remove(result['state'])!;
+    r.complete(result);
+    if (_requestsByState.isEmpty) {
+      for (var s in _requestServers.values) {
+        await (await s).close();
+      }
+      _requestServers.clear();
+    }
   }
 }
 


### PR DESCRIPTION
If the Login happens in an external Browser there is no way to process the authorization code received via the redirect uri.

Exposing the processing part custom responses can be handled and the callbacks of previously made calls are handled correctly 