### PR TITLE
Added 'flow' in 'Authenticator' constructor for customization.

### DIFF
--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -17,10 +17,12 @@ class Authenticator {
       {this.port = 3000,
       this.urlLancher = _runBrowser,
       Iterable<String> scopes = const [],
-      Uri? redirectUri})
-      : flow = redirectUri == null
-            ? Flow.authorizationCodeWithPKCE(client)
-            : Flow.authorizationCode(client)
+      Uri? redirectUri,
+      Flow? flow})
+      : flow = flow ??
+            (redirectUri == null
+                ? Flow.authorizationCodeWithPKCE(client)
+                : Flow.authorizationCode(client))
           ..scopes.addAll(scopes)
           ..redirectUri = redirectUri ?? Uri.parse('http://localhost:$port/');
 


### PR DESCRIPTION
Add an optional `Flow` in the `Authenticator constructor`, which will default to the current implementation when not given so as to not break any current implementations.
More information can be found in issue #55.

This PR closes issue #55.