### PR TITLE
redirectHtml parameter is added to Authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ authenticate(Uri uri, String clientId, List<String> scopes) async {
     // create an authenticator
     var authenticator = new Authenticator(client,
         scopes: scopes,
-        port: 4000, urlLancher: urlLauncher);
+        port: 4000, 
+        urlLancher: urlLauncher,
+        // if custom response needed on redirection 
+        redirectHtml: '<html>Redirecting...</html>'
+        );
     
     // starts the authentication
     var c = await authenticator.authorize();


### PR DESCRIPTION
redirectHtml parameter is added to Authenticator so that consumer can pass their own response html for localhost redirectUrl

Issue Url: https://github.com/appsup-dart/openid_client/issues/27