### PR TITLE
Fix a bug where only the first supported scope is included in the authentication request

### DIFF
--- a/lib/src/openid.dart
+++ b/lib/src/openid.dart
@@ -365,7 +365,6 @@ class Flow {
     for (var s in scopes) {
       if (supportedScopes.contains(s)) {
         this.scopes.add(s);
-        break;
       }
     }
 


### PR DESCRIPTION
The logic in the constructor for `Flow` checks if the requested scope is supported, but the `break` statement means it will stop processing after the first match. This means the library will only include the first matching scope in the request, rather than all scopes specified as intended.