### PR TITLE
Support for setting claims in the authorizationCodeWithPKCE flow

### DIFF
--- a/lib/src/openid.dart
+++ b/lib/src/openid.dart
@@ -394,8 +394,17 @@ class Flow {
             scopes: scopes,
             redirectUri: redirectUri);
 
-  Flow.authorizationCodeWithPKCE(Client client, {String? state})
-      : this._(FlowType.proofKeyForCodeExchange, 'code', client, state: state);
+  Flow.authorizationCodeWithPKCE(
+    Client client, {
+    String? state,
+    List<String> scopes = const ['openid', 'profile', 'email'],
+  }) : this._(
+          FlowType.proofKeyForCodeExchange,
+          'code',
+          client,
+          state: state,
+          scopes: scopes,
+        );
 
   Flow.implicit(Client client, {String? state})
       : this._(


### PR DESCRIPTION
`Flow.authorizationCodeWithPKCE` does not allow users to set the claims they wish to request from the IDP, so it defaults to `openid profile email`. This PR allows users to specify which claims they request