### PR TITLE
Bugfix: Enable non-ascii characters in JWT

### DIFF
--- a/lib/src/http_util.dart
+++ b/lib/src/http_util.dart
@@ -38,7 +38,8 @@ dynamic _processResponse(http.Response response) {
       .value;
   var isJson = contentType.split(';').first == 'application/json';
 
-  var body = isJson ? json.decode(response.body) : response.body;
+  var body = isJson ? json.decode(utf8.decode(response.body)) : response.body;
+
   if (body is Map && body['error'] is String) {
     throw OpenIdException(
         body['error'], body['error_description'], body['error_uri']);


### PR DESCRIPTION
**Problem**: When processing the response from an OpenID-Provider, the string is not decoded using UTF-8. Therefore, no non-ascii characters like german "Umlaute" (like ä, ü, ö) are possible in the JWT and therefore in the name in the JWT (like Jürgen).

**Fix**: in `lib/src/http_util.dart` `_processResponse`: before calling `json.decode` of the response, first decode it via `utf8.decode`.

**Result**: Umlaute and other non-ascii characters are now possible in the JWT and its fields like the name.