### PR TITLE
Decode JSON responses in UTF-8, not Latin-1

### DIFF
--- a/lib/src/http_util.dart
+++ b/lib/src/http_util.dart
@@ -38,7 +38,7 @@ dynamic _processResponse(http.Response response) {
       .value;
   var isJson = contentType.split(';').first == 'application/json';
 
-  var body = isJson ? json.decode(response.body) : response.body;
+  var body = isJson ? json.decode(utf8.decode(response.bodyBytes)) : response.body;
   if (body is Map && body['error'] is String) {
     throw OpenIdException(
         body['error'], body['error_description'], body['error_uri']);


### PR DESCRIPTION
As per RFC 4627, JSON is UTF-8 by default (with UTF-16 or UTF-32 as other two possible encodings). However, the http library uses Latin-1 decoding, unless there is an explicit character set definition in the response headers.
Most notably, this breaks `Credential.getUserInfo()` when the user's name has non-ASCII characters in it.