### PR TITLE
fix: apply provided scopes to auth flow in openid_client_io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## 0.4.8
+
+- **FIX**: update openid_client_io to apply provided scopes to the authorization flow instead of default values
+
 ## 0.4.7
 
  - **FIX**: update contentSecurityPolicy of keycloak server to allow silent refresh with iframe. ([df9ef506](https://github.com/appsup-dart/openid_client/commit/df9ef506d0dd3e690f86d5fcc2efd073f0a51109))
@@ -16,11 +22,10 @@
  - **DOCS**: add funding info. ([e006d6de](https://github.com/appsup-dart/openid_client/commit/e006d6de4473360c78722f7ad6226ad6a5fc3c29))
  - **DOCS**: add example usage with keycloak server. ([a2939419](https://github.com/appsup-dart/openid_client/commit/a29394192789931ec44d6e6b64f16765325505e4))
 
-# Changelog
-
 ## 0.4.6
 
 - keep old refresh token when access token refreshed and no new refresh token received
+
 ## 0.4.5
 
 - handle tokens without expiration

--- a/lib/openid_client_io.dart
+++ b/lib/openid_client_io.dart
@@ -57,7 +57,7 @@ class Authenticator {
     Client client, {
     this.port = 3000,
     this.urlLancher = _runBrowser,
-    Iterable<String> scopes = const [],
+    List<String> scopes = const [],
     Uri? redirectUri,
     String? redirectMessage,
     String? prompt,
@@ -68,8 +68,9 @@ class Authenticator {
         ),
         redirectMessage = redirectMessage ?? 'You can now close this window',
         flow = redirectUri == null
-            ? Flow.authorizationCodeWithPKCE(client, prompt: prompt)
-            : Flow.authorizationCode(client, prompt: prompt)
+            ? Flow.authorizationCodeWithPKCE(client,
+                prompt: prompt, scopes: scopes)
+            : Flow.authorizationCode(client, prompt: prompt, scopes: scopes)
           ..scopes.addAll(scopes)
           ..redirectUri = redirectUri ?? Uri.parse('http://localhost:$port/');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openid_client
 description: Library for working with OpenID Connect and implementing clients.
-version: 0.4.7
+version: 0.4.8
 homepage: https://github.com/appsup-dart/openid_client
 funding:
  - https://github.com/sponsors/rbellens


### PR DESCRIPTION
Pass the provided scopes to the authorization flow  initialization function
 so that the default values are not applied.

This allows the caller to configure the appropriate scopes for their authentication
 request in cases where the oath provider does not support one or more of
 the default openid, profile, or email scopes.