### PR TITLE
Use universal_html package instead of dart:html

### DIFF
--- a/lib/openid_client_browser.dart
+++ b/lib/openid_client_browser.dart
@@ -1,5 +1,5 @@
 import 'openid_client.dart';
-import 'dart:html' hide Credential, Client;
+import 'package:universal_html/html.dart' hide Credential, Client;
 import 'dart:async';
 export 'openid_client.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,12 @@ environment:
 dependencies:
   jose: ^0.3.2
   pointycastle: ^3.0.0
-  http: ^0.13.0
+  http: ">=0.13.5 <2.0.0"
   logging: ^1.0.0
   args: ^2.0.0
   meta: ^1.0.0
   clock: ^1.1.0
+  universal_html: ^2.2.3
 
 dev_dependencies:
   test: ^1.16.5


### PR DESCRIPTION
Use of `universal_html` instead of `dart:html` in order to allow for `Flutter` applications that are intended to run on multiple targets, e.g. Desktop **and** Web. 

Otherwise, the web related imports will cause errors during the flutter build for non-web platforms indicating the `html` related packages are not allowed to be used on those targets. Since `dart` does not support conditional imports, the `universal_html` package gets around this limitation and is intended for this type of use case.

https://pub.dev/packages/universal_html


This PR also relaxes the `http` package requirements to support the later versions which are still backwards compatible.
