### PR TITLE
set the revoke uri instead of token uri

### DIFF
--- a/lib/src/openid.dart
+++ b/lib/src/openid.dart
@@ -219,7 +219,7 @@ class Credential {
     if (methods.contains('client_secret_basic')) {
       var h = base64
           .encode('${client.clientId}:${client.clientSecret ?? ''}'.codeUnits);
-      await http.post(client.issuer.tokenEndpoint,
+      await http.post(uri,
           headers: {'authorization': 'Basic $h'},
           body: request,
           client: client.httpClient);


### PR DESCRIPTION
Hello,

I see you changed the revoke method in the last version, and you are calling the token endpoint instead of revoke if the client authentication method is client_secret_basic.

Thank you. 